### PR TITLE
Global plugin url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Iframe creates an interface that allows signed in users to browse their vid
 Here is a simple example of an iframe linking to your web application. (It is strongly recommended that you use a protocol-relative URL) 
 
 ```html
-<iframe id="clickview-plugin" width="800" height="494" src="//online.clickview.com.au/v3/plugins/base?consumerKey=xxxxxx"></iframe>
+<iframe id="clickview-plugin" width="800" height="494" src="https://integrations.clickviewapp.com/plugin?consumerKey=xxxxxx"></iframe>
 ```
 
 **To use the ClickView Plugin within your platform you will need to obtain a valid Consumer Key and developer credentials from ClickView.**
@@ -86,7 +86,7 @@ application:
 
 ## Iframe Example
 ```html
-<iframe id="clickview-plugin" width="800" height="494" src="//online.clickview.com.au/v3/plugins/base?consumerKey=xxxxxx&schoolId=00000000-0000-0000-0000-000000000000"></iframe>
+<iframe id="clickview-plugin" width="800" height="494" src="https://integrations.clickviewapp.com/plugin?consumerKey=xxxxxx&schoolId=00000000-0000-0000-0000-000000000000"></iframe>
 ```
 *NOTE: Our plugin will still function normally if the School ID is incorrect, taking the user to the default
 sign in page rather than the expected SSO page.*

--- a/README.md
+++ b/README.md
@@ -17,14 +17,6 @@ Here is a simple example of an iframe linking to your web application. (It is st
 **To use the ClickView Plugin within your platform you will need to obtain a valid Consumer Key and developer credentials from ClickView.**
 
 *NOTE: The minimum size for this Iframe is 570px by 350px, please do not make the iframe any smaller than this, we recommend an optimal size of 800px by 494px*
-### Host Locations
-*NOTE: You should select a host location appropriate to your geographic region otherwise your users will not be able to sign into our platform.*
-
-| Region | URL |
-| --- | --- |
-| Australia | http://online.clickview.com.au/v3/plugins/base |
-| England | http://online.clickview.co.uk/v3/plugins/base |
-| New Zealand | http://online.clickview.co.nz/v3/plugins/base |
 
 ### Query Parameters
 The following options are exposed via the query parameters:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Information about the video the user has selected.
 | thumbnailUrl | A thumbnail image of the selected video. |
 | embedLink | A link to our video player, use this in conjunction with the embed property if you wish to generate your own iframe. |
 | embed {Object} | <ul><li>autoplay: Boolean indicating if the user expects the video to play automatically on page load.</li><li>width: Width in pixels that user wishes the video to be.</li><li>height: Height in pixel that the user wishes the video to be.</li></ul> | 
-| fullLink | <ul><li>A link to this video within our website. Use this if you wish to link users to our video instead of embedding it within your platform.</li></ul>|
+| fullLink | A link to this video within our website. Use this if you wish to link users to our video instead of embedding it within your platform. |
 
 # Single Sign On
 Some of our customers who use a Sign Sign On system may wish to have their instance of our Plugin slightly customized to take them directly to their SSO Log in page when authenticating with our Plugin.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Information about the video the user has selected.
 | thumbnailUrl | A thumbnail image of the selected video. |
 | embedLink | A link to our video player, use this in conjunction with the embed property if you wish to generate your own iframe. |
 | embed {Object} | <ul><li>autoplay: Boolean indicating if the user expects the video to play automatically on page load.</li><li>width: Width in pixels that user wishes the video to be.</li><li>height: Height in pixel that the user wishes the video to be.</li></ul> | 
-| shortenedUrl {Object} | <ul><li>shortUrl: A link to this video within our website. Use this if you wish to link users to our video instead of embedding it within your platform.</li></ul>|
+| fullLink | <ul><li>A link to this video within our website. Use this if you wish to link users to our video instead of embedding it within your platform.</li></ul>|
 
 # Single Sign On
 Some of our customers who use a Sign Sign On system may wish to have their instance of our Plugin slightly customized to take them directly to their SSO Log in page when authenticating with our Plugin.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ http://static.clickview.com.au/cv-events-api/1.0.1/cv-events-api.min.js
 Feel free to embed this directly into your platform like so (It is strongly recommended that you use a
 protocol-relative URL).
 ```html
-<script src="//static.clickview.com.au/cv-events-api/1.1.1/cv-events-api.min.js" type="text/javascript"></script>
+<script src="https://static.clickview.com.au/cv-events-api/1.1.1/cv-events-api.min.js" type="text/javascript"></script>
 ```
 Or alternatively you may download the file and host it directly from your platform.
 


### PR DESCRIPTION
# Changes
- The `readme.md` has been updated to reflect that we now have a global entry point to our plugin. As such, the host locations heading has been removed, and the codepen example has been updated.
- Event details have been updated, the `shortUrl` property did not exist, it was actually `fullLink` and not an object.